### PR TITLE
provider: ark: return only spendable vtxos in getVirtualCoins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arklabs/wallet-sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Bitcoin wallet SDK with Taproot and Ark integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/providers/ark.ts
+++ b/src/providers/ark.ts
@@ -33,30 +33,20 @@ export class ArkProvider extends BaseArkProvider {
         }
         const data = await response.json();
 
-        // Convert from server format to our internal VTXO format
-        return [...(data.spendableVtxos || []), ...(data.spentVtxos || [])].map(
-            (vtxo) => ({
-                txid: vtxo.outpoint.txid,
-                vout: vtxo.outpoint.vout,
-                value: Number(vtxo.amount),
-                status: {
-                    confirmed: !!vtxo.roundTxid,
-                },
-                virtualStatus: {
-                    state: vtxo.spent
-                        ? "spent"
-                        : vtxo.swept
-                          ? "swept"
-                          : vtxo.isPending
-                            ? "pending"
-                            : "settled",
-                    batchTxID: vtxo.roundTxid,
-                    batchExpiry: vtxo.expireAt
-                        ? Number(vtxo.expireAt)
-                        : undefined,
-                },
-            })
-        );
+        // Convert from server format to our internal VTXO format and only return spendable coins (settled or pending)
+        return [...(data.spendableVtxos || [])].map((vtxo) => ({
+            txid: vtxo.outpoint.txid,
+            vout: vtxo.outpoint.vout,
+            value: Number(vtxo.amount),
+            status: {
+                confirmed: !!vtxo.roundTxid,
+            },
+            virtualStatus: {
+                state: vtxo.isPending ? "pending" : "settled",
+                batchTxID: vtxo.roundTxid,
+                batchExpiry: vtxo.expireAt ? Number(vtxo.expireAt) : undefined,
+            },
+        }));
     }
 
     async submitVirtualTx(psbtBase64: string): Promise<string> {


### PR DESCRIPTION
This PR includes a fix when fetching the virtual transaction (VTXOs) in the Bitcoin Wallet SDK with ARK integration.