### PR TITLE
Support Boarding

### DIFF
--- a/src/core/tree/validation.ts
+++ b/src/core/tree/validation.ts
@@ -124,7 +124,7 @@ export function validateVtxoTree(
         sha256x2(settlementTransaction.toBytes(true)).reverse()
     );
     if (
-        hex.encode(Buffer.from(rootInput.txid)) !== settlementTxid ||
+        hex.encode(rootInput.txid) !== settlementTxid ||
         rootInput.index !== SHARED_OUTPUT_INDEX
     ) {
         throw ErrWrongSettlementTxid;

--- a/src/core/tree/vtxoTree.ts
+++ b/src/core/tree/vtxoTree.ts
@@ -196,7 +196,7 @@ export function getCosignerKeys(tx: Transaction): Uint8Array[] {
 
     for (const unknown of input.unknown) {
         const ok = parsePrefixedCosignerKey(
-            Buffer.concat([new Uint8Array([unknown[0].type]), unknown[0].key])
+            new Uint8Array([unknown[0].type, ...unknown[0].key])
         );
 
         if (!ok) continue;

--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -696,7 +696,7 @@ export class Wallet implements IWallet {
                             ZERO_32
                         )
                     ) {
-                        throw new Error("Failed to sign settlement tx");
+                        throw new Error("Unable to sign the settlement transaction. Check your private key");
                     }
                 }
 

--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -696,7 +696,9 @@ export class Wallet implements IWallet {
                             ZERO_32
                         )
                     ) {
-                        throw new Error("Unable to sign the settlement transaction. Check your private key");
+                        throw new Error(
+                            "Unable to sign the settlement transaction. Check your private key"
+                        );
                     }
                 }
 

--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -674,9 +674,7 @@ export class Wallet implements IWallet {
                         );
                     }
 
-                    const inputTxId = Buffer.from(
-                        settlementInput.txid
-                    ).toString("hex");
+                    const inputTxId = hex.encode(settlementInput.txid);
                     if (inputTxId !== input.outpoint.txid) continue;
                     if (settlementInput.index !== input.outpoint.vout) continue;
 

--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -39,6 +39,12 @@ import { TxWeightEstimator } from "../utils/txSizeEstimator";
 import { validateConnectorsTree, validateVtxoTree } from "./tree/validation";
 import { TransactionOutput } from "@scure/btc-signer/psbt";
 
+const ZERO_32 = new Uint8Array([
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
 export class Wallet implements IWallet {
     private identity: Identity;
     private network: Network;
@@ -400,9 +406,9 @@ export class Wallet implements IWallet {
                             internalKey: btc.TAPROOT_UNSPENDABLE_KEY,
                             merklePath: selectedLeaf.path,
                         },
-                        Buffer.concat([
-                            selectedLeaf.script,
-                            Buffer.from([TAP_LEAF_VERSION]),
+                        new Uint8Array([
+                            ...selectedLeaf.script,
+                            TAP_LEAF_VERSION,
                         ]),
                     ],
                 ],
@@ -687,7 +693,7 @@ export class Wallet implements IWallet {
                             this.identity.privateKey(),
                             i,
                             undefined,
-                            Buffer.alloc(32)
+                            ZERO_32
                         )
                     ) {
                         throw new Error("Failed to sign settlement tx");
@@ -774,7 +780,7 @@ export class Wallet implements IWallet {
                 this.identity.privateKey(),
                 1,
                 undefined,
-                Buffer.alloc(32)
+                ZERO_32
             );
 
             signedForfeits.push(base64.encode(forfeitTx.toPSBT()));

--- a/src/core/wallet.ts
+++ b/src/core/wallet.ts
@@ -676,7 +676,7 @@ export class Wallet implements IWallet {
                         settlementInput.index === undefined
                     ) {
                         throw new Error(
-                            "Invalid settlement psbt, cannot sign boarding utxo"
+                            "The server returned incomplete data. No settlement input found in the PSBT"
                         );
                     }
 

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -42,16 +42,19 @@ export interface Recipient {
     amount: number;
 }
 
-export type ForfeitVtxoInput = VtxoInput & {
+// SpendableVtxo embed the forfeit script to use as spending path for the boarding utxo or vtxo
+export type SpendableVtxo = VtxoInput & {
     forfeitScript: string;
 };
 
 export interface SettleParams {
-    inputs: (string | ForfeitVtxoInput)[];
+    inputs: (string | SpendableVtxo)[];
     outputs: Output[];
 }
 
-export interface OffchainInfo {
+// VtxoTaprootAddress embed the tapscripts composing the address
+// it admits the internal key is the unspendable x-only public key
+export interface VtxoTaprootAddress {
     address: string;
     scripts: {
         exit: string[];
@@ -61,8 +64,8 @@ export interface OffchainInfo {
 
 export interface AddressInfo {
     onchain: string;
-    offchain?: OffchainInfo;
-    boarding?: string;
+    offchain?: VtxoTaprootAddress;
+    boarding?: VtxoTaprootAddress;
     bip21: string;
 }
 

--- a/test/address.test.ts
+++ b/test/address.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { ArkAddress } from '../src/core/address';
 import fixtures from './fixtures/encoding.json';
+import { hex } from '@scure/base';
 
 describe('ArkAddress', () => {
   describe('valid addresses', () => {
@@ -13,10 +14,10 @@ describe('ArkAddress', () => {
         expect(['ark', 'tark']).toContain(addr.hrp);
         
         // Check server public key matches expected
-        expect(Buffer.from(addr.serverPubKey).toString('hex')).toBe(fixture.expectedServerKey.slice(2)); // Remove '02' prefix
+        expect(hex.encode(addr.serverPubKey)).toBe(fixture.expectedServerKey.slice(2)); // Remove '02' prefix
         
         // Check VTXO taproot key matches expected
-        expect(Buffer.from(addr.tweakedPubKey).toString('hex')).toBe(fixture.expectedUserKey.slice(2)); // Remove '02' prefix
+        expect(hex.encode(addr.tweakedPubKey)).toBe(fixture.expectedUserKey.slice(2)); // Remove '02' prefix
         
         // Test encoding
         const encoded = addr.encode();

--- a/test/setup.js
+++ b/test/setup.js
@@ -16,7 +16,7 @@ async function execCommand(command) {
       // If the error indicates the wallet is already initialized, we can continue
       if (error.stderr && error.stderr.toString().includes('wallet already initialized')) {
         console.log('Wallet already initialized, continuing...')
-        resolve(Buffer.from(''))
+        resolve(new Uint8Array([]))
       } else {
         reject(error)
       }


### PR DESCRIPTION
This PR leverages the [previous work on settlement](https://github.com/ArkLabsHQ/wallet-sdk/pull/7) to support onboarding flow.

the user is now able to fund the boarding onchain address and then use it as input of a settlement tx in `settle` method.

it closes #13 

@altafan @tiero please review