### PR TITLE
Mark as side-effect-free to allow Tree Shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Add `sideEffects: false` allowing to enable [Tree Shaking whil bundling the lib](https://webpack.js.org/guides/tree-shaking/).

@tiero please review