### PR TITLE
`DefaultVtxo.Script` add default exit timelock

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -11,6 +11,7 @@ export interface WalletConfig {
     arkServerUrl?: string;
     arkServerPublicKey?: string;
     boardingTimelock?: RelativeTimelock;
+    exitTimelock?: RelativeTimelock;
 }
 
 export interface WalletBalance {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -92,11 +92,17 @@ export class Wallet implements IWallet {
 
         if (arkProvider) {
             let serverPubKeyHex = config.arkServerPublicKey;
-            let exitTimelock = config.boardingTimelock;
+            let exitTimelock = config.exitTimelock;
+            let boardingTimelock = config.boardingTimelock;
             if (!serverPubKeyHex || !exitTimelock) {
                 const info = await arkProvider.getInfo();
                 serverPubKeyHex = info.pubkey;
                 exitTimelock = {
+                    value: info.unilateralExitDelay,
+                    type:
+                        info.unilateralExitDelay < 512n ? "blocks" : "seconds",
+                };
+                boardingTimelock = {
                     value: info.unilateralExitDelay * 2n,
                     type:
                         info.unilateralExitDelay * 2n < 512n
@@ -114,7 +120,7 @@ export class Wallet implements IWallet {
             const boardingTapscript = new DefaultVtxo.Script({
                 pubKey: pubkey,
                 serverPubKey,
-                csvTimelock: exitTimelock,
+                csvTimelock: boardingTimelock,
             });
 
             // Save tapscripts


### PR DESCRIPTION
This PR updates the default CSV timelock value to fit the go-sdk ones. Making restore possible between WASM-based wallet & `wallet-sdk` wallet.

@tiero @altafan please review