### PR TITLE
Fix vtxo repository init

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -66,8 +66,8 @@ export class Wallet implements IWallet {
         private onchainP2TR: ReturnType<typeof p2tr>,
         private arkProvider?: ArkProvider,
         private arkServerPublicKey?: Bytes,
-        private offchainTapscript?: DefaultVtxo.Script,
-        private boardingTapscript?: DefaultVtxo.Script
+        readonly offchainTapscript?: DefaultVtxo.Script,
+        readonly boardingTapscript?: DefaultVtxo.Script
     ) {}
 
     static async create(config: WalletConfig): Promise<Wallet> {


### PR DESCRIPTION
This PR ensures that the service worker init step is also including spent vtxos (instead of only spendable ones). It allows correctly restore the tx history.

@tiero please review 