### PR TITLE
`getAddress`: return encoded addresses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
     Outpoint,
     VirtualCoin,
     TxKey,
+    Addresses,
 } from "./wallet/index";
 import { Wallet } from "./wallet/wallet";
 import { ServiceWorkerWallet } from "./wallet/serviceWorker/wallet";
@@ -112,6 +113,7 @@ export type {
     SettleParams,
     VtxoTaprootAddress,
     AddressInfo,
+    Addresses,
     TapscriptInfo,
     Status,
     VirtualStatus,

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -60,9 +60,14 @@ export interface VtxoTaprootAddress {
 }
 
 export interface AddressInfo {
+    offchain: VtxoTaprootAddress;
+    boarding: VtxoTaprootAddress;
+}
+
+export interface Addresses {
     onchain: string;
-    offchain?: VtxoTaprootAddress;
-    boarding?: VtxoTaprootAddress;
+    offchain?: string;
+    boarding?: string;
     bip21: string;
 }
 
@@ -131,7 +136,8 @@ export type ExtendedVirtualCoin = {
 
 export interface IWallet {
     // Address and balance management
-    getAddress(): Promise<AddressInfo>;
+    getAddress(): Promise<Addresses>;
+    getAddressInfo(): Promise<AddressInfo>;
     getBalance(): Promise<WalletBalance>;
     getCoins(): Promise<Coin[]>;
     getVtxos(): Promise<ExtendedVirtualCoin[]>;

--- a/src/wallet/serviceWorker/request.ts
+++ b/src/wallet/serviceWorker/request.ts
@@ -6,6 +6,7 @@ export namespace Request {
         | "INIT_WALLET"
         | "SETTLE"
         | "GET_ADDRESS"
+        | "GET_ADDRESS_INFO"
         | "GET_BALANCE"
         | "GET_COINS"
         | "GET_VTXOS"
@@ -66,6 +67,14 @@ export namespace Request {
 
     export function isGetAddress(message: Base): message is GetAddress {
         return message.type === "GET_ADDRESS";
+    }
+
+    export interface GetAddressInfo extends Base {
+        type: "GET_ADDRESS_INFO";
+    }
+
+    export function isGetAddressInfo(message: Base): message is GetAddressInfo {
+        return message.type === "GET_ADDRESS_INFO";
     }
 
     export interface GetBalance extends Base {

--- a/src/wallet/serviceWorker/response.ts
+++ b/src/wallet/serviceWorker/response.ts
@@ -3,8 +3,9 @@ import {
     Coin,
     VirtualCoin,
     ArkTransaction,
-    AddressInfo,
+    AddressInfo as WalletAddressInfo,
     IWallet,
+    Addresses,
 } from "..";
 import { SettlementEvent } from "../../providers/ark";
 
@@ -14,6 +15,7 @@ export namespace Response {
         | "SETTLE_EVENT"
         | "SETTLE_SUCCESS"
         | "ADDRESS"
+        | "ADDRESS_INFO"
         | "BALANCE"
         | "COINS"
         | "VTXOS"
@@ -92,18 +94,40 @@ export namespace Response {
     export interface Address extends Base {
         type: "ADDRESS";
         success: true;
-        address: AddressInfo;
+        addresses: Addresses;
     }
 
     export function isAddress(response: Base): response is Address {
         return response.type === "ADDRESS" && response.success === true;
     }
 
-    export function address(id: string, address: AddressInfo): Address {
+    export function addresses(id: string, addresses: Addresses): Address {
         return {
             type: "ADDRESS",
             success: true,
-            address,
+            addresses,
+            id,
+        };
+    }
+
+    export interface AddressInfo extends Base {
+        type: "ADDRESS_INFO";
+        success: true;
+        addressInfo: WalletAddressInfo;
+    }
+
+    export function isAddressInfo(response: Base): response is AddressInfo {
+        return response.type === "ADDRESS_INFO" && response.success === true;
+    }
+
+    export function addressInfo(
+        id: string,
+        addressInfo: WalletAddressInfo
+    ): AddressInfo {
+        return {
+            type: "ADDRESS_INFO",
+            success: true,
+            addressInfo,
             id,
         };
     }

--- a/src/wallet/serviceWorker/wallet.ts
+++ b/src/wallet/serviceWorker/wallet.ts
@@ -9,6 +9,7 @@ import {
     WalletConfig,
     ExtendedCoin,
     ExtendedVirtualCoin,
+    Addresses,
 } from "..";
 import { Request } from "./request";
 import { Response } from "./response";
@@ -205,7 +206,7 @@ export class ServiceWorkerWallet implements IWallet {
         });
     }
 
-    async getAddress(): Promise<AddressInfo> {
+    async getAddress(): Promise<Addresses> {
         const message: Request.GetAddress = {
             type: "GET_ADDRESS",
             id: getRandomId(),
@@ -214,11 +215,28 @@ export class ServiceWorkerWallet implements IWallet {
         try {
             const response = await this.sendMessage(message);
             if (Response.isAddress(response)) {
-                return response.address;
+                return response.addresses;
             }
             throw new UnexpectedResponseError(response);
         } catch (error) {
             throw new Error(`Failed to get address: ${error}`);
+        }
+    }
+
+    async getAddressInfo(): Promise<AddressInfo> {
+        const message: Request.GetAddressInfo = {
+            type: "GET_ADDRESS_INFO",
+            id: getRandomId(),
+        };
+
+        try {
+            const response = await this.sendMessage(message);
+            if (Response.isAddressInfo(response)) {
+                return response.addressInfo;
+            }
+            throw new UnexpectedResponseError(response);
+        } catch (error) {
+            throw new Error(`Failed to get address info: ${error}`);
         }
     }
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -74,7 +74,7 @@ describe("Wallet SDK Integration Tests", () => {
         const offchainAddress = aliceAddresses.offchain;
 
         // faucet
-        execSync(`nigiri faucet ${boardingAddress?.address} 0.001`);
+        execSync(`nigiri faucet ${boardingAddress} 0.001`);
 
         await new Promise((resolve) => setTimeout(resolve, 5000));
 
@@ -85,7 +85,7 @@ describe("Wallet SDK Integration Tests", () => {
             inputs: boardingInputs,
             outputs: [
                 {
-                    address: offchainAddress!.address,
+                    address: offchainAddress!,
                     amount: BigInt(100000),
                 },
             ],
@@ -97,8 +97,7 @@ describe("Wallet SDK Integration Tests", () => {
     it("should settle a VTXO", { timeout: 60000 }, async () => {
         // Create fresh wallet instance for this test
         const alice = await createTestWallet();
-        const aliceOffchainAddress = (await alice.wallet.getAddress()).offchain
-            ?.address;
+        const aliceOffchainAddress = (await alice.wallet.getAddress()).offchain;
         expect(aliceOffchainAddress).toBeDefined();
 
         const fundAmount = 1000;
@@ -190,9 +189,8 @@ describe("Wallet SDK Integration Tests", () => {
 
             // Get addresses
             const aliceOffchainAddress = (await alice.wallet.getAddress())
-                .offchain?.address;
-            const bobOffchainAddress = (await bob.wallet.getAddress()).offchain
-                ?.address;
+                .offchain;
+            const bobOffchainAddress = (await bob.wallet.getAddress()).offchain;
             expect(aliceOffchainAddress).toBeDefined();
             expect(bobOffchainAddress).toBeDefined();
 
@@ -258,17 +256,14 @@ describe("Wallet SDK Integration Tests", () => {
         const bob = await createTestWallet();
 
         // Get addresses
-        const aliceOffchainAddress = (await alice.wallet.getAddress()).offchain
-            ?.address;
-        const bobOffchainAddress = (await bob.wallet.getAddress()).offchain
-            ?.address;
+        const aliceOffchainAddress = (await alice.wallet.getAddress()).offchain;
+        const bobOffchainAddress = (await bob.wallet.getAddress()).offchain;
         expect(aliceOffchainAddress).toBeDefined();
         expect(bobOffchainAddress).toBeDefined();
 
         // Alice onboarding
         const boardingAmount = 10000;
-        const boardingAddress = (await alice.wallet.getAddress()).boarding
-            ?.address;
+        const boardingAddress = (await alice.wallet.getAddress()).boarding;
         execSync(
             `nigiri faucet ${boardingAddress} ${boardingAmount * 0.00000001}`
         );


### PR DESCRIPTION
This PR changes the `getAddress` return type in order to be consistent with the onchain address.
It also add `IWallet.getAddressInfo` to be able to access the ark vtxo scripts for offchain and boarding addresses.

it closes #45 

@tiero please review